### PR TITLE
Port @N3MI-DG changes needed for Klipper commit 7f5e918

### DIFF
--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -5,6 +5,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
 from . import probe
+from . import manual_probe
 
 if not hasattr(probe, 'ProbeOffsetsHelper'):
     try:
@@ -23,7 +24,7 @@ class ToolProbe:
         self.name = config.get_name()
         self.mcu_probe = probe.ProbeEndstopWrapper(config)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = ProbeSessionHelper(config, self.mcu_probe)
+        self.probe_session = ProbeSessionHelper(config, self.mcu_probe, self.probe_offsets)
 
         # Crash detection stuff
         pin = config.get('pin')
@@ -48,9 +49,10 @@ class ToolProbe:
 
 # Helper to track multiple probe attempts in a single command
 class ProbeSessionHelper:
-    def __init__(self, config, mcu_probe):
+    def __init__(self, config, mcu_probe, probe_offsets):
         self.printer = config.get_printer()
         self.mcu_probe = mcu_probe
+        self.probe_offsets = probe_offsets
         gcode = self.printer.lookup_object('gcode')
         self.dummy_gcode_cmd = gcode.create_gcode_command("", "", {})
         # Infer Z position to move to during a probe
@@ -142,7 +144,7 @@ class ProbeSessionHelper:
         # Allow axis_twist_compensation to update results
         self.printer.send_event("probe:update_results", epos)
         # Create ProbeResult
-        if hasattr(manual_probe, 'create_probe_result'): 
+        if hasattr(manual_probe, 'create_probe_result'):
             # Klipper post 7f5e918
             offsets = self.probe_offsets.get_offsets()
             result = manual_probe.create_probe_result(epos, offsets)
@@ -153,7 +155,7 @@ class ProbeSessionHelper:
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
                            % (epos[0], epos[1], epos[2]))
-        return epos[:3]
+        return result
     def run_probe(self, gcmd):
         if not self.multi_probe_pending:
             self._probe_state_error()
@@ -168,7 +170,7 @@ class ProbeSessionHelper:
             pos = self._probe(params['probe_speed'])
             positions.append(pos)
             # Check samples tolerance
-            z_positions = [p[2] for p in positions]
+            z_positions = [p.bed_z for p in positions]
             if max(z_positions)-min(z_positions) > params['samples_tolerance']:
                 if retries >= params['samples_tolerance_retries']:
                     raise gcmd.error("Probe samples exceed samples_tolerance")
@@ -178,7 +180,7 @@ class ProbeSessionHelper:
             # Retract
             if len(positions) < sample_count:
                 toolhead.manual_move(
-                    probexy + [pos[2] + params['sample_retract_dist']],
+                    probexy + [pos.bed_z + params['sample_retract_dist']],
                     params['lift_speed'])
         # Calculate result
         epos = probe.calc_probe_z_average(positions, params['samples_result'])

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -142,8 +142,13 @@ class ProbeSessionHelper:
         # Allow axis_twist_compensation to update results
         self.printer.send_event("probe:update_results", epos)
         # Create ProbeResult
-        offsets = self.probe_offsets.get_offsets()
-        result = manual_probe.create_probe_result(epos, offsets)
+        if hasattr(manual_probe, 'create_probe_result'): 
+            # Klipper post 7f5e918
+            offsets = self.probe_offsets.get_offsets()
+            result = manual_probe.create_probe_result(epos, offsets)
+        else:
+            # Legacy
+            result = self.probe_offsets.create_probe_result(epos)
         # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -141,6 +141,9 @@ class ProbeSessionHelper:
             raise self.printer.command_error(reason)
         # Allow axis_twist_compensation to update results
         self.printer.send_event("probe:update_results", epos)
+        # Create ProbeResult
+        offsets = self.probe_offsets.get_offsets()
+        result = manual_probe.create_probe_result(epos, offsets)
         # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -18,21 +18,6 @@ if not all(hasattr(probe, attr) for attr in (
     else:
         ensure_probe_backports(probe)
 
-# Helper class to provide probe offsets interface for ToolProbeEndstop
-class ToolProbeOffsetsHelper:
-    def __init__(self, tool_probe_endstop):
-        self.tool_probe_endstop = tool_probe_endstop
-
-    def get_offsets(self, gcmd=None):
-        return self.tool_probe_endstop.get_offsets(gcmd)
-
-    # Support legacy Klipper versions where HomingViaProbeHelper calls this
-    def create_probe_result(self, test_pos):
-        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
-        return manual_probe.ProbeResult(
-            test_pos[0]+x_offset, test_pos[1]+y_offset,
-            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
-
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
 # Or via auto-detection of single open tool probe via DETECT_ACTIVE_TOOL_PROBE
@@ -102,6 +87,13 @@ class ToolProbeEndstop:
         if self.active_probe:
             return self.active_probe.get_offsets()
         return 0.0, 0.0, 0.0
+
+    # Support legacy Klipper versions where HomingViaProbeHelper calls this
+    def create_probe_result(self, test_pos):
+        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
+        return manual_probe.ProbeResult(
+            test_pos[0]+x_offset, test_pos[1]+y_offset,
+            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
     
     def get_probe_params(self, gcmd=None):
         if self.active_probe:

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -18,6 +18,14 @@ if not all(hasattr(probe, attr) for attr in (
     else:
         ensure_probe_backports(probe)
 
+# Helper class to provide probe offsets interface for ToolProbeEndstop
+class ToolProbeOffsetsHelper:
+    def __init__(self, tool_probe_endstop):
+        self.tool_probe_endstop = tool_probe_endstop
+
+    def get_offsets(self, gcmd=None):
+        return self.tool_probe_endstop.get_offsets(gcmd)
+
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
 # Or via auto-detection of single open tool probe via DETECT_ACTIVE_TOOL_PROBE

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -26,6 +26,13 @@ class ToolProbeOffsetsHelper:
     def get_offsets(self, gcmd=None):
         return self.tool_probe_endstop.get_offsets(gcmd)
 
+    # Support legacy Klipper versions where HomingViaProbeHelper calls this
+    def create_probe_result(self, test_pos):
+        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
+        return manual_probe.ProbeResult(
+            test_pos[0]+x_offset, test_pos[1]+y_offset,
+            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
+
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
 # Or via auto-detection of single open tool probe via DETECT_ACTIVE_TOOL_PROBE


### PR DESCRIPTION
Klipper after [commit 7f5e918](https://github.com/Klipper3d/klipper/commit/7f5e918331dc1695899433915659337dc50176e0) breaks probing on multiple Z toolheads because KTH doesn't provide the necessary ProbeResult. 

https://github.com/jwellman80/klipper-toolchanger-easy/pull/12