### PR TITLE
Fix parameter reference for replacement M109 and M104

### DIFF
--- a/examples/macros.cfg
+++ b/examples/macros.cfg
@@ -10,7 +10,7 @@ gcode:
     {% if params.S is defined %}
       {% set newparams = newparams ~ " TARGET=" ~ params.S %}
     {% endif %}
-    SET_TOOL_TEMPERATURE{newparameters}
+    SET_TOOL_TEMPERATURE{newparams}
   {% else %}
     M104.1 {rawparams}
   {% endif %}
@@ -27,7 +27,7 @@ gcode:
     {% if params.S is defined %}
       {% set newparams = newparams ~ " TARGET=" ~ params.S %}
     {% endif %}
-    SET_TOOL_TEMPERATURE{newparameters}
+    SET_TOOL_TEMPERATURE{newparams}
   {% else %}
     M109.1 {rawparams}
   {% endif %}


### PR DESCRIPTION
I was testing my printer on multi-toolhead mode and noticed that every time I used the `M104 Tx Sy` syntax it wouldn't actually do anything. 

Taking a look at the macro, I noticed that `SET_TOOL_TEMPERATURE` got called with `{newparameters}` while the string built was `{newparams}`.

Sure enough, stuffing in a `RESPOND` put this on the output log:
`newparams= T=1 TARGET=150 newparameters=`